### PR TITLE
reset코드가 없을시 변경동작이 안되는 버그 수정 #164

### DIFF
--- a/app/Controllers/Lgn/Password.php
+++ b/app/Controllers/Lgn/Password.php
@@ -130,7 +130,8 @@ class Password extends BaseController
         $info = $model_result["info"];
 
         if ($info === null) {
-            redirect_alert("초기화 정보가 없습니다", "/");
+            redirect_alert("초기화 정보가 없습니다. 메일 요청을 여러번 하셨다면 가장 최근의 링크를 선택해주세요.", "/");
+            exit;
         }
 
         $today = date("YmdHis");


### PR DESCRIPTION
회원 암호 reset 시 reset 코드가 있어야하는데, 그 코드가 재발급으로 인해 DB에서 사라진 경우 redirect_alert를 표시하고 메인으로 가야 하는데, 그게 안되는 버그 exit가 없어서 생긴걸로 문구를 세분화하고 exit추가